### PR TITLE
Remove zenodo link

### DIFF
--- a/data/claims_denials/pa/readme.md
+++ b/data/claims_denials/pa/readme.md
@@ -66,8 +66,6 @@ You can also browse individual raw pdfs directly:
 
 - [UPMC Health Options (2020)](./raw/2020/UPMC%20Health%20Options%20109ef343-ffdc-4345-bd67-0e2fca6714cd_DATA_TRANSPARENCY_COVERAGE.pdf), [UPMC Health Options (2021)](./raw/2021/UPMC%20Health%20Options%20397c178b-497b-4770-b580-a2844721e3a8_DATA_TRANSPARENCY_COVERAGE.pdf)
 
-Or grab the data from this Zenodo mirror (TODO).
-
 ## Notes
 
 - Requested claims data from 2022 was not provided as claims from that plan year were still pending


### PR DESCRIPTION
This just removes a TODO that suggested a Zenodo link would be added to the dataset. No immediate plans to mirror the data to Zenodo.