### PR TITLE
CMS FOIA Request

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,11 @@ Visit the webpage for more information: https://repos.persius.org/public-records
 
 https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll
 
+- Install jekyll, ruby, gem
+
+- Install bundler
+
+- Run bundle exec jekyll serve
+
 
  -->

--- a/README.md
+++ b/README.md
@@ -2,3 +2,12 @@
 This repository houses source code and data that supports our site hosting public records we obtain.
 
 Visit the webpage for more information: https://repos.persius.org/public-records/.
+
+
+<!-- Test local build with Jekyll:
+
+
+https://docs.github.com/en/pages/setting-up-a-github-pages-site-with-jekyll/testing-your-github-pages-site-locally-with-jekyll
+
+
+ -->

--- a/index.md
+++ b/index.md
@@ -23,5 +23,5 @@ the status or outcome of the request.
 
 | Record Source | Date of Submission  | Status | Description |
 |:-------------|:------------------|:------    | :------    |
-| Centers for Medicare and Medicaid Services | 3/28/24 | [Submitted](#) | Complete technical documentation for the Medicare Appeals System (MAS). This is a collaboration with the [Data Liberation Project](https://www.data-liberation-project.org/). |
-| Centers for Medicare and Medicaid Services | 3/28/24 | [Submitted](#) | Case data for Level 2 Appeal outcomes for Medicare Parts A, B, C, and D dating back to 2015. This is a collaboration with the [Data Liberation Project](https://www.data-liberation-project.org/). |
+| Centers for Medicare and Medicaid Services | 3/28/24 | [Submitted](https://www.documentcloud.org/documents/24522699-2024-03-28-cms-mas-documentation-foia-request-gartnersinger-vine) | Complete technical documentation for the Medicare Appeals System (MAS). This is a collaboration with the [Data Liberation Project](https://www.data-liberation-project.org/). |
+| Centers for Medicare and Medicaid Services | 3/28/24 | [Submitted](https://www.documentcloud.org/documents/24522698-2024-03-28-cms-medicare-level-2-appeals-database-records-foia-request-gartnersinger-vine) | Case data for Level 2 Appeal outcomes for Medicare Parts A, B, C, and D dating back to 2015. This is a collaboration with the [Data Liberation Project](https://www.data-liberation-project.org/). |

--- a/index.md
+++ b/index.md
@@ -2,7 +2,7 @@ This site hosts public records obtained by Persius.
 
 ## Records
 
-This repository currently contains public records
+This repository currently contains successfully acquired public records
 pertaining to the following subjects.
 
 ### Claims Denial Data
@@ -14,3 +14,14 @@ pertaining to the following subjects.
     |:-------------|:------------------|:------| :----- |
     | PA Department of Insurance           | 6/12/2023 | 2020, 2021  | Portable Document Format (PDF) |
 
+
+## Requests
+
+The following list documents _requests_ which we are making publicly available, regardless of
+the status or outcome of the request.
+
+
+| Record Source | Date of Submission  | Status | Description |
+|:-------------|:------------------|:------    | :------    |
+| Centers for Medicare and Medicaid Services | 3/28/24 | [Submitted](#) | Complete technical documentation for the Medicare Appeals System (MAS). This is a collaboration with the [Data Liberation Project](https://www.data-liberation-project.org/). |
+| Centers for Medicare and Medicaid Services | 3/28/24 | [Submitted](#) | Case data for Level 2 Appeal outcomes for Medicare Parts A, B, C, and D dating back to 2015. This is a collaboration with the [Data Liberation Project](https://www.data-liberation-project.org/). |


### PR DESCRIPTION
This PR does two things:

- Records submission of two CMS FOIA requests covering Level 2 Medicare appeal data.
- Adds a note on developing and previewing a GH pages deployment of this `public-records` repository locally.